### PR TITLE
Enhance to track the mouse in the color picker zone only instead of tracking the mouse in the whole window

### DIFF
--- a/angular-color-picker.js
+++ b/angular-color-picker.js
@@ -238,10 +238,9 @@
 
                     doDrag(evt.offsetX || evt.layerX, evt.offsetY || evt.layerY);
 
-                    angular.element($window)
-                        .on('mousemove', onMouseMove)
+                    $element.on('mousemove', onMouseMove)
                         .one('mouseup', function () {
-                            angular.element($window).off('mousemove', onMouseMove);
+                            $element.off('mousemove', onMouseMove);
                         });
                 };
             }


### PR DESCRIPTION
I used this color picker in my ionic project and found that when I clicked on the window outside the color picker zone, the picker cursor will move to the bottom of the picker zone.
